### PR TITLE
Advice to update webauthn4j to 0.10.2

### DIFF
--- a/services/src/main/java/org/keycloak/credential/AttestationStatementConverter.java
+++ b/services/src/main/java/org/keycloak/credential/AttestationStatementConverter.java
@@ -16,6 +16,7 @@
 
 package org.keycloak.credential;
 
+import com.webauthn4j.converter.util.ObjectConverter;
 import org.keycloak.common.util.Base64Url;
 
 import com.webauthn4j.converter.util.CborConverter;
@@ -23,20 +24,20 @@ import com.webauthn4j.data.attestation.statement.AttestationStatement;
 
 public class AttestationStatementConverter {
 
-    private CborConverter converter;
+    private CborConverter cborConverter;
 
-    public AttestationStatementConverter(CborConverter converter) {
-        this.converter = converter;
+    public AttestationStatementConverter(ObjectConverter objectConverter) {
+        this.cborConverter = objectConverter.getCborConverter();
     }
 
     public String convertToDatabaseColumn(AttestationStatement attribute) {
         AttestationStatementSerializationContainer container = new AttestationStatementSerializationContainer(attribute);
-        return Base64Url.encode(converter.writeValueAsBytes(container));
+        return Base64Url.encode(cborConverter.writeValueAsBytes(container));
     }
 
     public AttestationStatement convertToEntityAttribute(String dbData) {
         byte[] data = Base64Url.decode(dbData);
-        AttestationStatementSerializationContainer container = converter.readValue(data, AttestationStatementSerializationContainer.class);
+        AttestationStatementSerializationContainer container = cborConverter.readValue(data, AttestationStatementSerializationContainer.class);
         return container.getAttestationStatement();
     }
 }

--- a/services/src/main/java/org/keycloak/credential/CredentialPublicKeyConverter.java
+++ b/services/src/main/java/org/keycloak/credential/CredentialPublicKeyConverter.java
@@ -16,6 +16,7 @@
 
 package org.keycloak.credential;
 
+import com.webauthn4j.converter.util.ObjectConverter;
 import org.keycloak.common.util.Base64Url;
 
 import com.webauthn4j.converter.util.CborConverter;
@@ -23,17 +24,17 @@ import com.webauthn4j.data.attestation.authenticator.COSEKey;
 
 public class CredentialPublicKeyConverter {
 
-    private CborConverter converter;
+    private CborConverter cborConverter;
 
-    public CredentialPublicKeyConverter(CborConverter converter) {
-        this.converter = converter;
+    public CredentialPublicKeyConverter(ObjectConverter objectConverter) {
+        this.cborConverter = objectConverter.getCborConverter();
     }
 
     public String convertToDatabaseColumn(COSEKey credentialPublicKey) {
-        return Base64Url.encode(converter.writeValueAsBytes(credentialPublicKey));
+        return Base64Url.encode(cborConverter.writeValueAsBytes(credentialPublicKey));
     }
 
     public COSEKey convertToEntityAttribute(String s) {
-        return converter.readValue(Base64Url.decode(s), COSEKey.class);
+        return cborConverter.readValue(Base64Url.decode(s), COSEKey.class);
     }
 }

--- a/services/src/main/java/org/keycloak/credential/WebAuthnCredentialProvider.java
+++ b/services/src/main/java/org/keycloak/credential/WebAuthnCredentialProvider.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import com.webauthn4j.converter.util.ObjectConverter;
 import org.jboss.logging.Logger;
 import org.keycloak.authentication.requiredactions.WebAuthnRegisterFactory;
 import org.keycloak.common.util.Base64;
@@ -32,7 +33,6 @@ import org.keycloak.models.UserModel;
 import com.webauthn4j.WebAuthnManager;
 import com.webauthn4j.authenticator.Authenticator;
 import com.webauthn4j.authenticator.AuthenticatorImpl;
-import com.webauthn4j.converter.util.CborConverter;
 import com.webauthn4j.data.AuthenticationData;
 import com.webauthn4j.data.AuthenticationParameters;
 import com.webauthn4j.data.attestation.authenticator.AAGUID;
@@ -54,12 +54,12 @@ public class WebAuthnCredentialProvider implements CredentialProvider<WebAuthnCr
     private CredentialPublicKeyConverter credentialPublicKeyConverter;
     private AttestationStatementConverter attestationStatementConverter;
 
-    public WebAuthnCredentialProvider(KeycloakSession session, CborConverter converter) {
+    public WebAuthnCredentialProvider(KeycloakSession session, ObjectConverter objectConverter) {
         this.session = session;
         if (credentialPublicKeyConverter == null)
-            credentialPublicKeyConverter = new CredentialPublicKeyConverter(converter);
+            credentialPublicKeyConverter = new CredentialPublicKeyConverter(objectConverter);
         if (attestationStatementConverter == null)
-            attestationStatementConverter = new AttestationStatementConverter(converter);
+            attestationStatementConverter = new AttestationStatementConverter(objectConverter);
     }
 
     private UserCredentialStore getCredentialStore() {

--- a/services/src/main/java/org/keycloak/credential/WebAuthnCredentialProviderFactory.java
+++ b/services/src/main/java/org/keycloak/credential/WebAuthnCredentialProviderFactory.java
@@ -16,15 +16,14 @@
 
 package org.keycloak.credential;
 
+import com.webauthn4j.converter.util.ObjectConverter;
 import org.keycloak.models.KeycloakSession;
-
-import com.webauthn4j.converter.util.CborConverter;
 
 public class WebAuthnCredentialProviderFactory implements CredentialProviderFactory<WebAuthnCredentialProvider> {
 
     public static final String PROVIDER_ID = "keycloak-webauthn";
 
-    private static CborConverter converter = new CborConverter();
+    private static ObjectConverter converter = new ObjectConverter();
 
     @Override
     public CredentialProvider create(KeycloakSession session) {

--- a/services/src/main/java/org/keycloak/credential/WebAuthnPasswordlessCredentialProvider.java
+++ b/services/src/main/java/org/keycloak/credential/WebAuthnPasswordlessCredentialProvider.java
@@ -18,7 +18,7 @@
 
 package org.keycloak.credential;
 
-import com.webauthn4j.converter.util.CborConverter;
+import com.webauthn4j.converter.util.ObjectConverter;
 import org.keycloak.authentication.requiredactions.WebAuthnPasswordlessRegisterFactory;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.credential.WebAuthnCredentialModel;
@@ -30,8 +30,8 @@ import org.keycloak.models.credential.WebAuthnCredentialModel;
  */
 public class WebAuthnPasswordlessCredentialProvider extends WebAuthnCredentialProvider {
 
-    public WebAuthnPasswordlessCredentialProvider(KeycloakSession session, CborConverter converter) {
-        super(session, converter);
+    public WebAuthnPasswordlessCredentialProvider(KeycloakSession session, ObjectConverter objectConverter) {
+        super(session, objectConverter);
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/credential/WebAuthnPasswordlessCredentialProviderFactory.java
+++ b/services/src/main/java/org/keycloak/credential/WebAuthnPasswordlessCredentialProviderFactory.java
@@ -18,7 +18,7 @@
 
 package org.keycloak.credential;
 
-import com.webauthn4j.converter.util.CborConverter;
+import com.webauthn4j.converter.util.ObjectConverter;
 import org.keycloak.models.KeycloakSession;
 
 /**
@@ -28,11 +28,11 @@ public class WebAuthnPasswordlessCredentialProviderFactory implements Credential
 
     public static final String PROVIDER_ID = "keycloak-webauthn-passwordless";
 
-    private static CborConverter converter = new CborConverter();
+    private static ObjectConverter objectConverter = new ObjectConverter();
 
     @Override
     public CredentialProvider create(KeycloakSession session) {
-        return new WebAuthnPasswordlessCredentialProvider(session, converter);
+        return new WebAuthnPasswordlessCredentialProvider(session, objectConverter);
     }
 
     @Override


### PR DESCRIPTION
As webauthn4j introduces ObjectConverter to hold CborConverter and JsonConverter, hold ObjectConverter instead of directly holding CborConverter
